### PR TITLE
Graphics/cpt 30 provide directional point spot lights

### DIFF
--- a/Assets/Shaders/scene.frag
+++ b/Assets/Shaders/scene.frag
@@ -57,12 +57,4 @@ void main(void)
 	fragColor.rgb = pow(fragColor.rgb, vec3(1.0 / 2.2f));
 	
 	fragColor.a = albedo.a;
-
-//fragColor.rgb = IN.normal;
-
-	//fragColor = IN.colour;
-	
-	//fragColor.xy = IN.texCoord.xy;
-	
-	//fragColor = IN.colour;
 }

--- a/CSC8503/GameTechRenderer.cpp
+++ b/CSC8503/GameTechRenderer.cpp
@@ -39,9 +39,11 @@ GameTechRenderer::GameTechRenderer(GameWorld& world) : OGLRenderer(*Window::GetW
 	glClearColor(1, 1, 1, 1);
 
 	//Set up the light properties
-	lightColour = Vector4(0.8f, 0.8f, 0.5f, 1.0f);
-	lightRadius = 1000.0f;
-	lightPosition = Vector3(-200.0f, 60.0f, -200.0f);
+	Vector4 lightColour = Vector4(0.8f, 0.8f, 0.5f, 1.0f);
+	float lightRadius = 1000.0f;
+	Vector3 lightPosition = Vector3(-200.0f, 60.0f, -200.0f);
+	PointLight* pointL = new PointLight(lightPosition, lightColour, lightRadius);
+	AddLight(pointL);
 
 	//Skybox!
 	skyboxShader = new OGLShader("skybox.vert", "skybox.frag");
@@ -163,8 +165,8 @@ void GameTechRenderer::RenderShadowMap() {
 
 	BindShader(*shadowShader);
 	int mvpLocation = glGetUniformLocation(shadowShader->GetProgramID(), "mvpMatrix");
-
-	Matrix4 shadowViewMatrix = Matrix4::BuildViewMatrix(lightPosition, Vector3(0, 0, 0), Vector3(0,1,0));
+	PointLight* pl = (PointLight*)mLights[0];
+	Matrix4 shadowViewMatrix = Matrix4::BuildViewMatrix(pl->GetPosition(), Vector3(0, 0, 0), Vector3(0, 1, 0));
 	Matrix4 shadowProjMatrix = Matrix4::Perspective(100.0f, 500.0f, 1, 45.0f);
 
 	Matrix4 mvMatrix = shadowProjMatrix * shadowViewMatrix;
@@ -231,10 +233,6 @@ void GameTechRenderer::RenderCamera() {
 	int hasTexLocation  = 0;
 	int shadowLocation  = 0;
 
-	int lightPosLocation	= 0;
-	int lightColourLocation = 0;
-	int lightRadiusLocation = 0;
-
 	int cameraLocation = 0;
 
 	//TODO - PUT IN FUNCTION
@@ -258,22 +256,14 @@ void GameTechRenderer::RenderCamera() {
 			hasVColLocation = glGetUniformLocation(shader->GetProgramID(), "hasVertexColours");
 			hasTexLocation  = glGetUniformLocation(shader->GetProgramID(), "hasTexture");
 
-			lightPosLocation	= glGetUniformLocation(shader->GetProgramID(), "lightPos");
-			lightColourLocation = glGetUniformLocation(shader->GetProgramID(), "lightColour");
-			lightRadiusLocation = glGetUniformLocation(shader->GetProgramID(), "lightRadius");
-
 			cameraLocation = glGetUniformLocation(shader->GetProgramID(), "cameraPos");
 
 			Vector3 camPos = gameWorld.GetMainCamera().GetPosition();
 			glUniform3fv(cameraLocation, 1, &camPos.x);
 
 			glUniformMatrix4fv(projLocation, 1, false, (float*)&projMatrix);
-			glUniformMatrix4fv(viewLocation, 1, false, (float*)&viewMatrix);
-
-			glUniform3fv(lightPosLocation	, 1, (float*)&lightPosition);
-			glUniform4fv(lightColourLocation, 1, (float*)&lightColour);
-			glUniform1f(lightRadiusLocation , lightRadius);
-
+			glUniformMatrix4fv(viewLocation, 1, false, (float*)&viewMatrix);			
+			SendLightDataToShader(shader);
 			int shadowTexLocation = glGetUniformLocation(shader->GetProgramID(), "shadowTex");
 			glUniform1i(shadowTexLocation, 1);
 
@@ -468,4 +458,47 @@ void GameTechRenderer::SetDebugLineBufferSizes(size_t newVertCount) {
 
 		glBindVertexArray(0);
 	}
+}
+
+void GameTechRenderer::AddLight(Light* lightPtr) {
+	
+	mLights.push_back(lightPtr);
+}
+
+void GameTechRenderer::SendLightDataToShader(OGLShader* shader)
+{
+	for(int i = 0; i < mLights.size(); i++)
+	{
+		Light::Type type = mLights[i]->GetType();
+		if (type == Light::Point) {
+			SendPointLightDataToShader(shader, (PointLight*) mLights[i]);
+		}
+		else if (type == Light::Spot) {
+			SendSpotLightDataToShader(shader, (SpotLight*) mLights[i]);
+		}
+		else if (type == Light::Direction) {
+			SendDirLightDataToShader(shader, (DirectionLight*) mLights[i]);
+		}
+	}
+}
+
+void GameTechRenderer::SendPointLightDataToShader(OGLShader* shader, PointLight* l) {
+	int lightPosLocation = 0;
+	int lightColourLocation = 0;
+	int lightRadiusLocation = 0;
+
+	lightPosLocation = glGetUniformLocation(shader->GetProgramID(), "lightPos");
+	lightColourLocation = glGetUniformLocation(shader->GetProgramID(), "lightColour");
+	lightRadiusLocation = glGetUniformLocation(shader->GetProgramID(), "lightRadius");
+	glUniform3fv(lightPosLocation, 1, l->GetPositionAddress());
+	glUniform4fv(lightColourLocation, 1, l->GetColourAddress());
+	glUniform1f(lightRadiusLocation, l->GetRadius());
+}
+
+void GameTechRenderer::SendDirLightDataToShader(OGLShader* shader, DirectionLight* l) {
+
+}
+
+void GameTechRenderer::SendSpotLightDataToShader(OGLShader* shader, SpotLight* l) {
+
 }

--- a/CSC8503/GameTechRenderer.h
+++ b/CSC8503/GameTechRenderer.h
@@ -5,7 +5,10 @@
 #include "OGLMesh.h"
 
 #include "GameWorld.h"
-#include <Frustum.h>
+#include "Frustum.h"
+#include "DirectionalLight.h"
+#include "PointLight.h"
+#include "SpotLight.h"
 
 namespace NCL {
 	class Maths::Vector3;
@@ -22,9 +25,12 @@ namespace NCL {
 			Texture*	LoadTexture(const std::string& name);
 			Shader*		LoadShader(const std::string& vertex, const std::string& fragment);
 
+			void AddLight(Light* light);
+
 		protected:
 			void NewRenderLines();
 			void NewRenderText();
+			
 
 			void RenderFrame()	override;
 
@@ -43,6 +49,11 @@ namespace NCL {
 			void SetDebugStringBufferSizes(size_t newVertCount);
 			void SetDebugLineBufferSizes(size_t newVertCount);
 
+			void SendLightDataToShader(OGLShader* shader);
+			void SendPointLightDataToShader(OGLShader* shader, PointLight* l);
+			void SendSpotLightDataToShader(OGLShader* shader, SpotLight* l);
+			void SendDirLightDataToShader(OGLShader* shader, DirectionLight* l);
+
 			vector<const RenderObject*> activeObjects;
 
 			OGLShader*  debugShader;
@@ -55,10 +66,6 @@ namespace NCL {
 			GLuint		shadowTex;
 			GLuint		shadowFBO;
 			Matrix4     shadowMatrix;
-
-			Vector4		lightColour;
-			float		lightRadius;
-			Vector3		lightPosition;
 
 			//Debug data storage things
 			vector<Vector3> debugLineData;
@@ -76,6 +83,7 @@ namespace NCL {
 			GLuint textColourVBO;
 			GLuint textTexVBO;
 			size_t textCount;
+			vector<Light*> mLights;
 
 			Frustum mFrameFrustum;
 		};

--- a/CSC8503CoreClasses/BaseLight.h
+++ b/CSC8503CoreClasses/BaseLight.h
@@ -2,10 +2,13 @@
 #include "Vector4.h"
 #include "Vector3.h"
 
+using namespace NCL;
+using namespace Maths;
+
 class BaseLight {
 public:
-	Light() {};
-	virtual ~Light() = 0 {};
+	BaseLight() {};
+	virtual ~BaseLight() = 0 {};
 	Vector4 GetColour() const { return colour; }
 	void SetColour(const Vector4& val) { colour = val; }
 	std::string GetName() const { return name; }

--- a/CSC8503CoreClasses/BaseLight.h
+++ b/CSC8503CoreClasses/BaseLight.h
@@ -9,12 +9,18 @@ class BaseLight {
 public:
 	BaseLight() {};
 	virtual ~BaseLight() = 0 {};
-	Vector4 GetColour() const { return colour; }
-	void SetColour(const Vector4& val) { colour = val; }
-	std::string GetName() const { return name; }
+	Vector4 GetColour() const { 
+		return mColour; 
+	}
+	void SetColour(const Vector4& val) { 
+		mColour = val; 
+	}
+	std::string GetName() const { 
+		return mName; 
+	}
 
 protected:
-	Vector4 colour;
-	Vector4 intensity;
-	std::string name;
+	Vector4 mColour;
+	Vector4 mIntensity;
+	std::string mName;
 };

--- a/CSC8503CoreClasses/BaseLight.h
+++ b/CSC8503CoreClasses/BaseLight.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "Vector4.h"
+#include "Vector3.h"
+
+class BaseLight {
+public:
+	Light() {};
+	virtual ~Light() = 0 {};
+	Vector4 GetColour() const { return colour; }
+	void SetColour(const Vector4& val) { colour = val; }
+	std::string GetName() const { return name; }
+
+protected:
+	Vector4 colour;
+	Vector4 intensity;
+	std::string name;
+};

--- a/CSC8503CoreClasses/BaseLight.h
+++ b/CSC8503CoreClasses/BaseLight.h
@@ -5,22 +5,35 @@
 using namespace NCL;
 using namespace Maths;
 
-class BaseLight {
+class Light {
 public:
-	BaseLight() {};
-	virtual ~BaseLight() = 0 {};
+
+	enum Type {
+		Spot,
+		Point,
+		Direction
+	};
+
+	virtual ~Light() = 0 {};
 	Vector4 GetColour() const { 
 		return mColour; 
 	}
+
+	const float* GetColourAddress() const {
+		const float *address = &mColour.x;
+		return address;
+	}
+
+
 	void SetColour(const Vector4& val) { 
 		mColour = val; 
 	}
-	std::string GetName() const { 
-		return mName; 
+	Type GetType() const { 
+		return mType; 
 	}
 
 protected:
 	Vector4 mColour;
 	Vector4 mIntensity;
-	std::string mName;
+	Type mType;
 };

--- a/CSC8503CoreClasses/CMakeLists.txt
+++ b/CSC8503CoreClasses/CMakeLists.txt
@@ -57,6 +57,14 @@ set(Collision_Detection
 )
 source_group("Collision Detection" FILES ${Collision_Detection})
 
+set(Lights
+"BaseLight.h" 
+"DirectionalLight.h"
+"PointLight.h"
+"SpotLight.h"
+)
+source_group("Lights" FILES ${Lights})
+
 set(Networking
     "GameClient.h"  
     "GameClient.cpp"
@@ -135,7 +143,8 @@ set(ALL_FILES
     ${Collision_Detection}
     ${Networking}
     ${Physics}
-    ${enet_Files}   
+    ${enet_Files}
+    ${Lights}
 )
 
 set_source_files_properties(${ALL_FILES} PROPERTIES LANGUAGE CXX)

--- a/CSC8503CoreClasses/DirectionalLight.h
+++ b/CSC8503CoreClasses/DirectionalLight.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/CSC8503CoreClasses/DirectionalLight.h
+++ b/CSC8503CoreClasses/DirectionalLight.h
@@ -4,14 +4,14 @@
 using namespace NCL;
 using namespace Maths;
 
-class DirectionLight : public BaseLight
+class DirectionLight : public Light
 {
 public:
 	DirectionLight(Vector3 direction, const Vector4& colour) {
 		direction.Normalise();
 		this->mDirection = direction;
 		this->mColour = colour;
-		mName = "direction";
+		mType = Direction;
 	}
 
 	~DirectionLight(void) {};

--- a/CSC8503CoreClasses/DirectionalLight.h
+++ b/CSC8503CoreClasses/DirectionalLight.h
@@ -1,1 +1,24 @@
 #pragma once
+#include "BaseLight.h"
+
+using namespace NCL;
+using namespace Maths;
+
+class DirectionLight : public BaseLight
+{
+public:
+	DirectionLight(Vector3 direction, const Vector4& colour)
+	{
+		direction.Normalise();
+		this->direction = direction;
+		this->colour = colour;
+		name = "direction";
+	}
+
+	~DirectionLight(void) {};
+	Vector3 GetDirection() const { return direction; }
+	void SetDirection(const Vector3& val) { direction = val; }
+
+protected:
+	Vector3 direction;
+};

--- a/CSC8503CoreClasses/DirectionalLight.h
+++ b/CSC8503CoreClasses/DirectionalLight.h
@@ -7,18 +7,21 @@ using namespace Maths;
 class DirectionLight : public BaseLight
 {
 public:
-	DirectionLight(Vector3 direction, const Vector4& colour)
-	{
+	DirectionLight(Vector3 direction, const Vector4& colour) {
 		direction.Normalise();
-		this->direction = direction;
-		this->colour = colour;
-		name = "direction";
+		this->mDirection = direction;
+		this->mColour = colour;
+		mName = "direction";
 	}
 
 	~DirectionLight(void) {};
-	Vector3 GetDirection() const { return direction; }
-	void SetDirection(const Vector3& val) { direction = val; }
+	Vector3 GetDirection() const { 
+		return mDirection; 
+	}
+	void SetDirection(const Vector3& val) { 
+		mDirection = val; 
+	}
 
 protected:
-	Vector3 direction;
+	Vector3 mDirection;
 };

--- a/CSC8503CoreClasses/PointLight.h
+++ b/CSC8503CoreClasses/PointLight.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/CSC8503CoreClasses/PointLight.h
+++ b/CSC8503CoreClasses/PointLight.h
@@ -4,20 +4,26 @@
 using namespace NCL;
 using namespace Maths;
 
-class PointLight : public BaseLight
+class PointLight : public Light
 {
 public:
 	PointLight(const Vector3& position, const Vector4& colour, float radius) {
 		this->mPosition = position;
 		this->mColour = colour;
 		this->mRadius = radius;
-		mName = "point";
+		mType = Point;
 	}
 
 	~PointLight() {};
 	Vector3 GetPosition() const { 
 		return mPosition; 
 	}
+	
+	const float *GetPositionAddress() const {
+		const float* address = &mPosition.x;
+		return address;
+	}
+
 	void SetPosition(const Vector3& val) { 
 		mPosition = val; 
 	}
@@ -27,6 +33,7 @@ public:
 	void SetRadius(float val) { 
 		mRadius = val; 
 	}
+
 protected:
 	Vector3 mPosition;
 	float mRadius;

--- a/CSC8503CoreClasses/PointLight.h
+++ b/CSC8503CoreClasses/PointLight.h
@@ -1,1 +1,26 @@
 #pragma once
+#include "BaseLight.h"
+
+using namespace NCL;
+using namespace Maths;
+
+class PointLight : public BaseLight
+{
+public:
+	PointLight(const Vector3& position, const Vector4& colour, float radius)
+	{
+		this->position = position;
+		this->colour = colour;
+		this->radius = radius;
+		name = "point";
+	}
+
+	~PointLight(void) {};
+	Vector3 GetPosition() const { return position; }
+	void SetPosition(const Vector3& val) { position = val; }
+	float GetRadius() const { return radius; }
+	void SetRadius(float val) { radius = val; }
+protected:
+	Vector3 position;
+	float radius;
+};

--- a/CSC8503CoreClasses/PointLight.h
+++ b/CSC8503CoreClasses/PointLight.h
@@ -7,20 +7,27 @@ using namespace Maths;
 class PointLight : public BaseLight
 {
 public:
-	PointLight(const Vector3& position, const Vector4& colour, float radius)
-	{
-		this->position = position;
-		this->colour = colour;
-		this->radius = radius;
-		name = "point";
+	PointLight(const Vector3& position, const Vector4& colour, float radius) {
+		this->mPosition = position;
+		this->mColour = colour;
+		this->mRadius = radius;
+		mName = "point";
 	}
 
-	~PointLight(void) {};
-	Vector3 GetPosition() const { return position; }
-	void SetPosition(const Vector3& val) { position = val; }
-	float GetRadius() const { return radius; }
-	void SetRadius(float val) { radius = val; }
+	~PointLight() {};
+	Vector3 GetPosition() const { 
+		return mPosition; 
+	}
+	void SetPosition(const Vector3& val) { 
+		mPosition = val; 
+	}
+	float GetRadius() const { 
+		return mRadius; 
+	}
+	void SetRadius(float val) { 
+		mRadius = val; 
+	}
 protected:
-	Vector3 position;
-	float radius;
+	Vector3 mPosition;
+	float mRadius;
 };

--- a/CSC8503CoreClasses/SpotLight.h
+++ b/CSC8503CoreClasses/SpotLight.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/CSC8503CoreClasses/SpotLight.h
+++ b/CSC8503CoreClasses/SpotLight.h
@@ -4,23 +4,23 @@
 using namespace NCL;
 using namespace Maths;
 
-class Spotlight : public PointLight
+class SpotLight : public PointLight
 {
 public:
 	/*
 	Spotlights illuminate an angle with light. They consist of a bright inner ring, and a small & dimmer outer ring, to give a softer edge. 
 	The 'degreesDimming' parameter sets the difference between these two rings.  
 	*/
-	Spotlight(const Vector3& dir, const Vector3& pos, const Vector4& colour, float radius, float angle, float degreesDimming)
+	SpotLight(const Vector3& dir, const Vector3& pos, const Vector4& colour, float radius, float angle, float degreesDimming)
 		:PointLight(pos, colour, radius)	{
 		mAngle = angle;
 		mDirection = dir;
 		mDotProdMin = cosf((angle / 2) * (PI / 180));
 		mDimProdMin = cosf(((angle - degreesDimming) / 2) * (PI / 180));
 		mDirection = Vector3(0, 0, -1);
-		mName = "spot";
+		mType = Spot;
 	}
-	~Spotlight() {};
+	~SpotLight() {};
 	float GetAngle() const { 
 		return mAngle; 
 	}

--- a/CSC8503CoreClasses/SpotLight.h
+++ b/CSC8503CoreClasses/SpotLight.h
@@ -7,26 +7,43 @@ using namespace Maths;
 class Spotlight : public PointLight
 {
 public:
-	Spotlight(const Vector3& position, const Vector4& colour, float radius, float angle)
-		:PointLight(position, colour, radius)
-	{
-		this->angle = angle;
-		dotProdMin = cosf((angle / 2) * (PI / 180));
-		dimProdMin = cosf(((angle - 2) / 2) * (PI / 180));
-		direction = Vector3(0, 0, -1);
-		name = "spot";
+	/*
+	Spotlights illuminate an angle with light. They consist of a bright inner ring, and a small & dimmer outer ring, to give a softer edge. 
+	The 'degreesDimming' parameter sets the difference between these two rings.  
+	*/
+	Spotlight(const Vector3& dir, const Vector3& pos, const Vector4& colour, float radius, float angle, float degreesDimming)
+		:PointLight(pos, colour, radius)	{
+		mAngle = angle;
+		mDirection = dir;
+		mDotProdMin = cosf((angle / 2) * (PI / 180));
+		mDimProdMin = cosf(((angle - degreesDimming) / 2) * (PI / 180));
+		mDirection = Vector3(0, 0, -1);
+		mName = "spot";
 	}
-	~Spotlight(void) {};
-	float GetAngle() const { return angle; }
-	void SetAngle(float angle) { this->angle = angle; dotProdMin = cosf(angle / 2); }
-	Vector3 GetDirection() const { return direction; }
-	void SetDirection(const Vector3& dir) { direction = dir; }
-	float GetDotProdMin() const { return dotProdMin; }
-	float GetDimProdMin() const { return dimProdMin; }
+	~Spotlight() {};
+	float GetAngle() const { 
+		return mAngle; 
+	}
+	void SetAngle(float angle) { 
+		mAngle = angle; 
+		mDotProdMin = cosf(angle / 2); 
+	}
+	Vector3 GetDirection() const { 
+		return mDirection; 
+	}
+	void SetDirection(const Vector3& dir) { 
+		mDirection = dir; 
+	}
+	float GetDotProdMin() const { 
+		return mDotProdMin; 
+	}
+	float GetDimProdMin() const { 
+		return mDimProdMin; 
+	}
 
 protected:
-	float angle;
-	float dotProdMin;
-	float dimProdMin;
-	Vector3 direction;
+	float mAngle;
+	float mDotProdMin;
+	float mDimProdMin;	
+	Vector3 mDirection;
 };

--- a/CSC8503CoreClasses/SpotLight.h
+++ b/CSC8503CoreClasses/SpotLight.h
@@ -1,1 +1,32 @@
 #pragma once
+#include "PointLight.h"
+
+using namespace NCL;
+using namespace Maths;
+
+class Spotlight : public PointLight
+{
+public:
+	Spotlight(const Vector3& position, const Vector4& colour, float radius, float angle)
+		:PointLight(position, colour, radius)
+	{
+		this->angle = angle;
+		dotProdMin = cosf((angle / 2) * (PI / 180));
+		dimProdMin = cosf(((angle - 2) / 2) * (PI / 180));
+		direction = Vector3(0, 0, -1);
+		name = "spot";
+	}
+	~Spotlight(void) {};
+	float GetAngle() const { return angle; }
+	void SetAngle(float angle) { this->angle = angle; dotProdMin = cosf(angle / 2); }
+	Vector3 GetDirection() const { return direction; }
+	void SetDirection(const Vector3& dir) { direction = dir; }
+	float GetDotProdMin() const { return dotProdMin; }
+	float GetDimProdMin() const { return dimProdMin; }
+
+protected:
+	float angle;
+	float dotProdMin;
+	float dimProdMin;
+	Vector3 direction;
+};


### PR DESCRIPTION
Working on providing C++ support for spot, point, and directional lights. I've pulled out some of the hard-coded light code in GameTechRenderer to allow them to be added as variables instead, but at present only the original point-light will function. This is because shader support for each of these types is out of scope of this task, because it will be done with deferred rendering, which will require rewriting the entire rendering/shader pipeline. I don't want to bog down this task in that much more complex one, so this one just covers C++ support for the idea of multiple different lights ... that we can't turn on just yet!