### PR TITLE
Networking/CTP-151-Game-End-State-Packet

### DIFF
--- a/CSC8503CoreClasses/NetworkBase.h
+++ b/CSC8503CoreClasses/NetworkBase.h
@@ -17,7 +17,8 @@ enum BasicNetworkMessages {
 	Shutdown,
 	VariableUpdate,
 	SyncPlayers,
-	GameState
+	GameStartState,
+	GameEndState
 };
 
 struct GamePacket {

--- a/CSC8503CoreClasses/NetworkObject.cpp
+++ b/CSC8503CoreClasses/NetworkObject.cpp
@@ -21,11 +21,18 @@ void SyncPlayerListPacket::SyncPlayerList(std::vector<int>& clientPlayerList) co
 	}
 }
 
-GameStatePacket::GameStatePacket(bool val) {
-	type = BasicNetworkMessages::GameState;
-	size = sizeof(GameStatePacket);
+GameStartStatePacket::GameStartStatePacket(bool val) {
+	type = BasicNetworkMessages::GameStartState;
+	size = sizeof(GameStartStatePacket);
 
 	isGameStarted = val;
+}
+
+GameEndStatePacket::GameEndStatePacket(bool val){
+	type = BasicNetworkMessages::GameStartState;
+	size = sizeof(GameStartStatePacket);
+
+	isGameEnded = val;
 }
 
 NetworkObject::NetworkObject(GameObject& o, int id) : object(o)	{

--- a/CSC8503CoreClasses/NetworkObject.h
+++ b/CSC8503CoreClasses/NetworkObject.h
@@ -39,7 +39,6 @@ namespace NCL::CSC8503 {
 			cameraPosition = Vector3(0,0,0);
 		}
 	};
-
 	
 	struct SyncPlayerListPacket : public GamePacket {
 		int playerList[4];
@@ -48,13 +47,18 @@ namespace NCL::CSC8503 {
 		void SyncPlayerList(std::vector<int>& clientPlayerList) const;
 	};
 
-	struct GameStatePacket : public GamePacket {
+	struct GameStartStatePacket : public GamePacket {
 		bool isGameStarted = false;
-		GameStatePacket(bool val);
+		GameStartStatePacket(bool val);
+	};
+
+	struct GameEndStatePacket : public GamePacket{
+		bool isGameEnded = false;
+		GameEndStatePacket(bool val);
 	};
 
 
-	class NetworkObject		{
+	class NetworkObject	{
 	public:
 		NetworkObject(GameObject& o, int id);
 		virtual ~NetworkObject();


### PR DESCRIPTION
- Seperated GameState packet into two packets that called "GameStartState" and "GameEndState" for able to change game state without touching any other script in the class. Can merge them into single packet in the future.