### PR TITLE
Cpt 194/graphics   implement proper ordering for z culling

### DIFF
--- a/CSC8503/GameTechRenderer.cpp
+++ b/CSC8503/GameTechRenderer.cpp
@@ -170,7 +170,6 @@ void GameTechRenderer::RenderFrame() {
 	glClearColor(1, 1, 1, 1);	
 	BuildObjectList();
 	SortObjectList();
-	if(!mLights.empty()) RenderShadowMap();
 	RenderCamera();
 	RenderSkybox();
 	

--- a/CSC8503/GameTechRenderer.cpp
+++ b/CSC8503/GameTechRenderer.cpp
@@ -191,9 +191,10 @@ void GameTechRenderer::BuildObjectList() {
 	gameWorld.OperateOnContents(
 		[&](GameObject* o) {
 			if (o->IsActive()) {
-			const RenderObject* rendObj = o->GetRenderObject();
+			RenderObject* rendObj = o->GetRenderObject();
 			bool isInFrustum = mFrameFrustum.SphereInsideFrustum(o->GetTransform().GetPosition(), o->GetRenderObject()->GetCullSphereRadius());
 				if (rendObj && isInFrustum) {
+					rendObj->SetSqDistToCam(gameWorld.GetMainCamera().GetPosition());
 					activeObjects.emplace_back(rendObj);
 				}
 			}

--- a/CSC8503CoreClasses/RenderObject.h
+++ b/CSC8503CoreClasses/RenderObject.h
@@ -61,6 +61,10 @@ namespace NCL {
 				return mSqDistToCam;
 			}
 
+			void SetSqDistToCam(const Vector3& camPos) {
+				mSqDistToCam = (camPos - mTransform->GetPosition()).LengthSquared();
+			}
+
 			void SetSqDistToCam(float sqDist) {
 				mSqDistToCam = sqDist;
 			}

--- a/CSC8503CoreClasses/RenderObject.h
+++ b/CSC8503CoreClasses/RenderObject.h
@@ -2,6 +2,7 @@
 #include "Texture.h"
 #include "Shader.h"
 #include "Mesh.h"
+#include "Transform.h"
 
 namespace NCL {
 	using namespace NCL::Rendering;


### PR DESCRIPTION
The squareddistancetocamera is pushed into the renderobject by GameTechRenderer. 

This will help with some overdraw issues, but unfortunately not initiate the early Z test, because the stencil buffer is in action :( 