### PR TITLE
Items-And-Pickups/CTP-250-prevent-screwdriver-usage-unless-its-properly-used

### DIFF
--- a/CSC8503/InventoryBuffSystem/PlayerInventory.cpp
+++ b/CSC8503/InventoryBuffSystem/PlayerInventory.cpp
@@ -103,8 +103,8 @@ bool InventoryBuffSystem::PlayerInventory::HandleOnItemUsed(item item, int playe
 	return false;
 }
 
-ItemUseType InventoryBuffSystem::PlayerInventory::GetItemUseType(item item) {
-	return mItemToItemUseTypeMap[item];
+ItemUseType InventoryBuffSystem::PlayerInventory::GetItemUseType(item inItem) {
+	return mItemToItemUseTypeMap[inItem];
 }
 
 void InventoryBuffSystem::PlayerInventory::Attach(PlayerInventoryObserver* observer) {

--- a/CSC8503/InventoryBuffSystem/PlayerInventory.cpp
+++ b/CSC8503/InventoryBuffSystem/PlayerInventory.cpp
@@ -103,6 +103,10 @@ bool InventoryBuffSystem::PlayerInventory::HandleOnItemUsed(item item, int playe
 	return false;
 }
 
+ItemUseType InventoryBuffSystem::PlayerInventory::GetItemUseType(item item) {
+	return mItemToItemUseTypeMap[item];
+}
+
 void InventoryBuffSystem::PlayerInventory::Attach(PlayerInventoryObserver* observer) {
 	mInventoryObserverList.push_back(observer);
 }

--- a/CSC8503/InventoryBuffSystem/PlayerInventory.h
+++ b/CSC8503/InventoryBuffSystem/PlayerInventory.h
@@ -51,7 +51,7 @@ namespace InventoryBuffSystem
 		void UseItemInPlayerSlot(int itemSlot, int playerNo, int itemUseCount);
 		bool ItemInPlayerInventory(item inItem, int playerNo);
 		bool HandleOnItemUsed(item item, int playerNo, int invSlot, int itemUseCount);
-		ItemUseType GetItemUseType(item item);
+		ItemUseType GetItemUseType(item inItem);
 
 
 		void Attach(PlayerInventoryObserver* observer);

--- a/CSC8503/InventoryBuffSystem/PlayerInventory.h
+++ b/CSC8503/InventoryBuffSystem/PlayerInventory.h
@@ -51,6 +51,8 @@ namespace InventoryBuffSystem
 		void UseItemInPlayerSlot(int itemSlot, int playerNo, int itemUseCount);
 		bool ItemInPlayerInventory(item inItem, int playerNo);
 		bool HandleOnItemUsed(item item, int playerNo, int invSlot, int itemUseCount);
+		ItemUseType GetItemUseType(item item);
+
 
 		void Attach(PlayerInventoryObserver* observer);
 		void Detach(PlayerInventoryObserver* observer);

--- a/CSC8503/InventoryBuffSystem/PlayerInventory.h
+++ b/CSC8503/InventoryBuffSystem/PlayerInventory.h
@@ -25,6 +25,11 @@ namespace InventoryBuffSystem
 
 	const int MAX_INVENTORY_SLOTS = 2;
 
+	enum ItemUseType {
+		DirectUse,
+		NeedInteractableToUse
+	};
+
 	class PlayerInventory
 	{
 	public:
@@ -89,6 +94,13 @@ namespace InventoryBuffSystem
 			{ screwdriver, 2 },
 			{ disguise, 1 },
 			{ soundEmitter, 1 }
+		};
+
+		std::map<item, ItemUseType> mItemToItemUseTypeMap = {
+			{ screwdriver, NeedInteractableToUse},
+			{ disguise, DirectUse },
+			{ soundEmitter, DirectUse },
+			{ none, DirectUse }
 		};
 
 		std::map<item, std::function<bool(int playerNo)>> mItemPreconditionsMet;

--- a/CSC8503CoreClasses/PlayerObject.h
+++ b/CSC8503CoreClasses/PlayerObject.h
@@ -47,6 +47,8 @@ namespace NCL {
 			InventoryBuffSystemClass* mInventoryBuffSystemClassPtr;
 
 			virtual void MovePlayer(float dt);
+
+			virtual void OnPlayerUseItem();
 			
 			void RayCastFromPlayer(GameWorld* world);
 


### PR DESCRIPTION
- Added an enum called "ItemUseType". With that we can directly use an item if it is not dependent on anything to use or prevent to use item if it is dependent to something Ex:(screwdriver needs a vent.)