### PR TITLE
Fix memory leak

### DIFF
--- a/CSC8503/LevelManager.h
+++ b/CSC8503/LevelManager.h
@@ -155,7 +155,6 @@ namespace NCL {
 
 			// shaders
 			Shader* mBasicShader;
-			Shader* mSoldierShader;
 
 			// animation 
 			Mesh* mGuardMesh;

--- a/CSC8503CoreClasses/AnimationSystem.cpp
+++ b/CSC8503CoreClasses/AnimationSystem.cpp
@@ -27,6 +27,11 @@ void AnimationSystem::Clear()
 	mAnimationList.clear();
 	mGuardList.clear();
 	mPlayerList.clear();
+	for (auto& texID : mAnimTexID) {
+		glDeleteTextures(1, &texID);
+	}
+	mAnimTexID.clear();
+	
 }
 
 void AnimationSystem::Update(float dt, vector<GameObject*> UpdatableObjects,std::map<std::string,MeshAnimation*> preAnimationList)
@@ -171,7 +176,7 @@ void AnimationSystem::PreloadMatTextures(GameTechRenderer& renderer)
 						std::cout << texID << endl;
 						NCL::Rendering::OGLRenderer::SetTextureRepeating(texID, true);
 					}
-					
+					mAnimTexID.emplace_back(texID);
 					mMatTextures.emplace_back(texID);
 					if (mMatTextures.size() == o->GetRenderObject()->GetMesh()->GetSubMeshCount()) {
 						o->GetRenderObject()->SetMatTextures(mMatTextures);	

--- a/CSC8503CoreClasses/AnimationSystem.h
+++ b/CSC8503CoreClasses/AnimationSystem.h
@@ -62,6 +62,7 @@ namespace NCL {
 			vector<GuardObject*> mGuardList;
 			vector<PlayerObject*> mPlayerList;
 			vector<GLuint>  mMatTextures;
+			vector<GLuint>  mAnimTexID;
 			Shader* mShader;
 			Mesh* mMesh;
 			MeshAnimation* mAnim;


### PR DESCRIPTION
When we enter the next level, all GameObjects will be cleared, so I also need to clear all textures uploaded to the GPU(I forgot it before this version).

Their textureID are stored in RenderObject which will be deleted, So I have to load it and bind it in every level.